### PR TITLE
[WIP]購入ボタンのテキストと購入した時に出るalertのテキストを変更した

### DIFF
--- a/Aretct/Controller/CheckoutVC.swift
+++ b/Aretct/Controller/CheckoutVC.swift
@@ -149,7 +149,7 @@ extension CheckoutVC: STPPaymentContextDelegate {
             message = error?.localizedDescription ?? ""
         case .success:
             title = "Success!"
-            message = "Thank you for your purchase."
+            message = "購入ありがとうございます！"
         case .userCancellation:
             return
         }

--- a/Aretct/Storyboards/Base.lproj/Main.storyboard
+++ b/Aretct/Storyboards/Base.lproj/Main.storyboard
@@ -102,7 +102,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="fry-aa-TlZ"/>
                                 </constraints>
-                                <state key="normal" title="Place Order">
+                                <state key="normal" title="購入を確定する">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
                                 <connections>
@@ -344,6 +344,6 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="ude-dY-RK5"/>
-        <segue reference="VlC-T1-n9l"/>
+        <segue reference="Zq6-cu-n4v"/>
     </inferredMetricsTieBreakers>
 </document>


### PR DESCRIPTION
# What 
購入ボタンのテキストと購入した時に出るalertのテキストを変更した


# Why
英語表記ではなく、日本語表記の方が正しいため

# Issue
#25 